### PR TITLE
Added event IsReady flag to fix inaccessible drive errors for not-ready drives.

### DIFF
--- a/TeslaCamViewer/TeslaCamViewer/MainWindow.xaml.cs
+++ b/TeslaCamViewer/TeslaCamViewer/MainWindow.xaml.cs
@@ -188,9 +188,9 @@ namespace TeslaCamViewer
                 {
                     // Get all drives
                     var drives = System.IO.DriveInfo.GetDrives();
-                    drives = drives.Where(e => e.DriveType == DriveType.Removable ||
-                        e.DriveType == DriveType.Network ||
-                        e.DriveType == DriveType.Fixed).ToArray();
+                    drives = drives.Where(e => e.DriveType == DriveType.Removable && e.IsReady ||
+                        e.DriveType == DriveType.Network && e.IsReady ||
+                        e.DriveType == DriveType.Fixed && e.IsReady).ToArray();
 
                     // Find the first drive containing a TeslaCam folder and select that folder
                     teslaCamDir = (from drive in drives


### PR DESCRIPTION
Fix for drives that aren't ready, like memory card readers that are empty or network drives that haven't been authenticated to.