### PR TITLE
Add support for alternate Model 3 camera file name

### DIFF
--- a/TeslaCamViewer/TeslaCamViewer/TeslaCamDate.cs
+++ b/TeslaCamViewer/TeslaCamViewer/TeslaCamDate.cs
@@ -9,7 +9,8 @@ namespace TeslaCamViewer
 {
     public class TeslaCamDate
     {
-        private const string FileFormat = "yyyy-MM-dd_HH-mm";
+        private const string FileFormatNoSeconds = "yyyy-MM-dd_HH-mm";
+        private const string FileFormatWithSeconds = "yyyy-MM-dd_HH-mm-ss";
         private const string DisplayFormat = "M/d/yyyy h:mm tt";
 
         public string UTCDateString { get; private set; }
@@ -25,23 +26,16 @@ namespace TeslaCamViewer
         {
             get
             {
-
                 DateTime dt;
-                if (DateTime.TryParseExact(UTCDateString, FileFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out dt))
-                {
-                    return dt;
-                }
-                else
-                {
-                    throw new Exception("Invalid date format: " + UTCDateString);
-                }
+                if (DateTime.TryParseExact(UTCDateString, FileFormatNoSeconds, CultureInfo.InvariantCulture, DateTimeStyles.None, out dt)) return dt;
+                if (DateTime.TryParseExact(UTCDateString, FileFormatWithSeconds, CultureInfo.InvariantCulture, DateTimeStyles.None, out dt)) return dt;
+                throw new Exception("Invalid date format: " + UTCDateString);
             }
         }
         public DateTime LocalTimeStamp
         {
             get
             {
-
                 return UTCTimeStamp;
             }
         }

--- a/TeslaCamViewer/TeslaCamViewer/TeslaCamFile.cs
+++ b/TeslaCamViewer/TeslaCamViewer/TeslaCamFile.cs
@@ -18,7 +18,7 @@ namespace TeslaCamViewer
             FRONT,
             RIGHT_REPEATER
         }
-        private readonly string FileNameRegex = "([0-9]{4}-[0-9]{2}-[0-9]{2}_[0-9]{2}-[0-9]{2})-([a-z_]*).mp4";
+        private readonly string FileNameRegex = "([0-9]{4}-[0-9]{2}-[0-9]{2}_[0-9]{2}-[0-9]{2}(-[0-9]{2})?)-([a-z_]*).mp4";
         public string FilePath { get; private set; }
         public string FileName { get { return System.IO.Path.GetFileName(FilePath); } }
         public TeslaCamDate Date { get; private set; }
@@ -33,7 +33,8 @@ namespace TeslaCamViewer
             if (m.Count != 1)
                 throw new Exception("Invalid TeslaCamFile '" + FileName + "'");
             this.Date = new TeslaCamDate(m[0].Groups[1].Value);
-            string cameraType = m[0].Groups[2].Value;
+            int cameraTypeIndex = m[0].Groups.Count - 1;
+            string cameraType = m[0].Groups[cameraTypeIndex].Value;
             if (cameraType == "front")
                 CameraLocation = CameraType.FRONT;
             else if (cameraType == "left_repeater")


### PR DESCRIPTION
This is a really cool app- but when I first tried using it, it would just freeze and not do anything. Looking at the source code I realized it was failing to parse files with a seconds portion of the timestamp in the file name. Not sure if this is a new development in how the files are named or specific to the Model 3, but all my camera file names contained the seconds portion in the file name (e.g. `2019-07-22_17-12-36-front.mp4` instead of `2019-07-22_17-12-front.mp4`) so I couldn't view any of the camera files with the app.

This PR provides support for this "new" file name convention as well as the original convention.